### PR TITLE
Support API 21 for legacy devices

### DIFF
--- a/build-orbot.sh
+++ b/build-orbot.sh
@@ -4,7 +4,7 @@ rm -f ../OrbotLib.aar
 rm -f ../OrbotLib-sources.jar
 
 # should match Orbot's...
-export MIN_ANDROID_SDK=23
+export MIN_ANDROID_SDK=21
 
 if [ -d IPtProxy ]; then
   cd IPtProxy


### PR DESCRIPTION
tor-android already supports API 21.  Also, Orbot builds and runs fine when minSdk is set to 21.