### PR TITLE
OrbotIPtProxy Updates

### DIFF
--- a/build-orbot.sh
+++ b/build-orbot.sh
@@ -4,7 +4,7 @@ rm -f ../OrbotLib.aar
 rm -f ../OrbotLib-sources.jar
 
 # should match Orbot's...
-export MIN_ANDROID_SDK=21
+export MIN_ANDROID_SDK=24
 
 if [ -d IPtProxy ]; then
   cd IPtProxy


### PR DESCRIPTION
- Bump to IPtProxy 4.2.0, with lyrebird 0.6.1
- Bump min android sdk from 21 -> 24, matching Orbot's (should produce smaller binaries) 